### PR TITLE
Fix the double-reporting of looks under some circumstances

### DIFF
--- a/apps/habit/main.cpp
+++ b/apps/habit/main.cpp
@@ -220,7 +220,10 @@ int main(int argc, char *argv[])
 	// If -q is set, hijack the whole process, analyze the file, and get out.
     if (parser.isSet("q"))
     {
-    	checkHabFileForDups(parser.value("q"));
+    	QString s;
+    	QTextStream scannerOutput(&s);
+    	int i = HResults::checkHabFileForDups(parser.value("q"), scannerOutput);
+    	qDebug() << "Found " << i << " duplicate looks.";
     	return 0;
     }
 
@@ -390,6 +393,7 @@ int main(int argc, char *argv[])
     return ii;
 }
 
+#if 0
 bool checkHabFileForDups(const QString& sPath)
 {
 	bool b = false;
@@ -433,3 +437,4 @@ bool checkHabFileForDups(const QString& sPath)
 	}
 	return b;
 }
+#endif

--- a/distribution/files/habit-copyright.rtf
+++ b/distribution/files/habit-copyright.rtf
@@ -7,7 +7,7 @@
 
 \f0\fs24 \cf0 Habit is the proprietary property of The Regents of the University of California (\'93The Regents.\'94)\
 \
-Copyright \'a9 2018 The Regents of the University of California, Davis campus. All Rights Reserved.  \
+Copyright \'a9 2022 The Regents of the University of California, Davis campus. All Rights Reserved.  \
 \
 Redistribution and use in source and binary forms, with or without modification, are permitted by nonprofit, research institutions for research use only, provided that the following conditions are met:\
 \
@@ -39,7 +39,7 @@ For commercial license information please contact
 \b0 \
 Habit uses third party software libraries that are distributed under their own terms:\
 \
-Qt 5.9.1 ({\field{\*\fldinst{HYPERLINK "https://www.qt.io/"}}{\fldrslt https://www.qt.io}}) is distributed under the Gnu Public License, version 3. \
+Qt 5.15.2 ({\field{\*\fldinst{HYPERLINK "https://www.qt.io/"}}{\fldrslt https://www.qt.io}}) is distributed under the Gnu Public License, version 3. \
 Gstreamer 1.12.4 ({\field{\*\fldinst{HYPERLINK "https://gstreamer.freedesktop.org/"}}{\fldrslt https://gstreamer.freedesktop.org}}) is released under the Lesser Gnu Public License. \
 \
 \

--- a/habit2.pri
+++ b/habit2.pri
@@ -21,10 +21,11 @@
 	#QMAKE_LFLAGS += -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 
     CONFIG += c++11
-    LIBS += -Lc:/gstreamer/1.0/x86_64/lib -lgstreamer-1.0 -lglib-2.0 -lgobject-2.0 -lintl 
-#    LIBS += -lgstreamer-1.0 -lglib-2.0 -lintl 
-    INCLUDEPATH +=  \
-                    c:/gstreamer/1.0/x86_64/include/glib-2.0 \
-                    c:/gstreamer/1.0/x86_64/lib/glib-2.0/include \
-                    c:/gstreamer/1.0/x86_64/include/gstreamer-1.0
+	
+	# djs change to backslashes for windows
+	# change additions to INCLUDEPATH to single line
+    LIBS += -Lc:\gstreamer\1.0\msvc_x86_64\lib -lgstreamer-1.0 -lglib-2.0 -lgobject-2.0 -lintl 
+    INCLUDEPATH += c:\gstreamer\1.0\msvc_x86_64\include\glib-2.0
+    INCLUDEPATH += c:\gstreamer\1.0\msvc_x86_64\lib\glib-2.0\include
+    INCLUDEPATH += c:\gstreamer\1.0\msvc_x86_64\include\gstreamer-1.0
 }

--- a/habit2.pro
+++ b/habit2.pro
@@ -1,7 +1,7 @@
 #MAKEFILE = Makefile.qmake
 TEMPLATE = subdirs
 CONFIG += qt debug_and_release
-SUBDIRS = habutil habit hg3 gstqt fdhunt testmm testmisc gstsp
+SUBDIRS = habutil habit gstqt testmm testmisc
 
 # habresults gplayer testmm hgstplayer 
 habutil.subdir = libs/habutil

--- a/libs/habutil/HApplication.h
+++ b/libs/habutil/HApplication.h
@@ -14,7 +14,7 @@ class HApplication : public QApplication
 {
 	Q_OBJECT
 public:
-	HApplication(int &argc, char **argv[]) : QApplication(argc, *argv) {};
+	HApplication(int &argc, char *argv[]) : QApplication(argc, argv) {};
 	~HApplication() {};
 protected:
 	bool event(QEvent* event);

--- a/libs/habutil/HExperiment.cpp
+++ b/libs/habutil/HExperiment.cpp
@@ -9,6 +9,7 @@
 #include "HElapsedTimer.h"
 #include "HLookDetector.h"
 #include "HGMM.h"
+#include "HQEvents.h"
 #include <QObject>
 #include <algorithm>
 
@@ -20,6 +21,9 @@ HExperiment::HExperiment(HEventLog& log, HLookDetector& ld, QState* parent)
 	connect(&m_ld, SIGNAL(attention()), this, SLOT(onAttention()));
 	connect(&m_ld, SIGNAL(look(HLook)), this, SLOT(onLook(HLook)));
 	connect(&m_ld, SIGNAL(lookAborted(HLook)), this, SLOT(onLookAborted(HLook)));
+	connect(&m_ld, SIGNAL(maxAccumulatedLookTime()), this, SLOT(onMaxAccumulatedLookTime()));
+	connect(&m_ld, SIGNAL(phaseAccumulatedLookTime()), this, SLOT(onPhaseAccumulatedLookTime()));
+
 };
 
 void HExperiment::onAttention()
@@ -31,6 +35,17 @@ void HExperiment::onAttention()
 void HExperiment::onLook(HLook l)
 {
 	eventLog().append(new HLookEvent(l, HElapsedTimer::elapsed()));
+	machine()->postEvent(new HGotLookQEvent());
+}
+
+void HExperiment::onMaxAccumulatedLookTime()
+{
+	machine()->postEvent(new HMaxAccumulatedLookTimeQEvent());
+}
+
+void HExperiment::onPhaseAccumulatedLookTime()
+{
+	machine()->postEvent(new HPhaseAccumulatedLookTimeQEvent());
 }
 
 void HExperiment::onLookAborted(HLook l)

--- a/libs/habutil/HExperiment.h
+++ b/libs/habutil/HExperiment.h
@@ -114,6 +114,8 @@ private Q_SLOTS:
 	void onAttention();
 	void onLook(HLook l);
 	void onLookAborted(HLook l);
+	void onMaxAccumulatedLookTime();
+	void onPhaseAccumulatedLookTime();
 	void onPhaseStarted(QString phaseName);
 	void onPhaseEnded(QString phaseName);
 

--- a/libs/habutil/HLooker.cpp
+++ b/libs/habutil/HLooker.cpp
@@ -385,8 +385,10 @@ void HLooker::onLookingStateEntered()
 						l.setLookMS(cumulativeLookTimeMS);
 					}
 					m_looks.append(l);
-					//qDebug() << "emit look(1): " << l;
-					//qDebug() << "sublooks follow" << endl << sublooks;
+					qDebug() << "emit look(1): " << l;
+					qDebug() << "sublooks follow" << endl << sublooks;
+
+					// update looking parameters before emit
 					emit look(l);
 				}
 				else
@@ -723,8 +725,8 @@ void HLooker::minLookAwayTimeout()
 			}
 
 			m_looks.append(l);
-			//qDebug() << "emit look(2, inclusive=" << m_bInclusiveLookTime << "): " << l;
-			//qDebug() << "sublooks follow" << endl << sublooks;
+			qDebug() << "emit look(2, inclusive=" << m_bInclusiveLookTime << "): " << l;
+			qDebug() << "sublooks follow" << endl << sublooks;
 			emit look(l);
 
 		}
@@ -768,8 +770,10 @@ void HLooker::stopLooker(int tMS)
 	// Stop any active timers.
 	// Flush out any look or lookaway pending.
 
+	qDebug() << "HLooker::stopLooker()";
 	if (isLive())
 	{
+		qDebug() << "HLooker::stopLooker() - isLive() = true";
 		if (m_ptimerMinLookTime->isActive()) m_ptimerMinLookTime->stop();
 		if (m_ptimerMinLookAwayTime->isActive()) m_ptimerMinLookAwayTime->stop();
 		if (m_ptimerMaxLookAway->isActive()) m_ptimerMaxLookAway->stop();
@@ -784,18 +788,19 @@ void HLooker::stopLooker(int tMS)
 		int lookStartTimeMS;
 		int lastLookStartTimeMS;
 		HLookList sublooks;
+		qDebug() << "HLooker::stopLooker() - m_bLookStarted = true";
 		if (!analyzeLooking(m_iLookStartedIndex, lookStartTimeMS, lastLookStartTimeMS, cumulativeLookTimeMS, lastLookAwayStartTimeMS, sublooks))
 		{
 			qCritical() << "Cannot analyze looking at index " << m_iLookStartedIndex;
 			return;
 		}
 
-		//qDebug() << "analyzeLooking(): m_iLookStartedIndex = " << m_iLookStartedIndex;
-		//qDebug() << "analyzeLooking(): lookStartTimeMS = " << lookStartTimeMS;
-		//qDebug() << "analyzeLooking(): lastLookStartTimeMS = " << lastLookStartTimeMS;
-		//qDebug() << "analyzeLooking(): cumulativeLookTimeMS = " << cumulativeLookTimeMS;
-		//qDebug() << "analyzeLooking(): lastLookAwayStartTimeMS = " << lastLookAwayStartTimeMS;
-		//qDebug() << "analyzeLooking(): sublooks.size = " << sublooks.size();
+		qDebug() << "analyzeLooking(): m_iLookStartedIndex = " << m_iLookStartedIndex;
+		qDebug() << "analyzeLooking(): lookStartTimeMS = " << lookStartTimeMS;
+		qDebug() << "analyzeLooking(): lastLookStartTimeMS = " << lastLookStartTimeMS;
+		qDebug() << "analyzeLooking(): cumulativeLookTimeMS = " << cumulativeLookTimeMS;
+		qDebug() << "analyzeLooking(): lastLookAwayStartTimeMS = " << lastLookAwayStartTimeMS;
+		qDebug() << "analyzeLooking(): sublooks.size = " << sublooks.size();
 
 
 		if (m_bLookAwayStarted)
@@ -803,6 +808,7 @@ void HLooker::stopLooker(int tMS)
 			// Since a lookaway has started, the current state is LookAway, so the cumulativeLookTime is the
 			// it, no need to add the additional from last transition to tMS. If the cumulativeLookTime is
 			// sufficient, emit a look, otherwise do nothing.
+			qDebug() << "HLooker::stopLooker() - m_bLookAwayStarted = true";
 			if (cumulativeLookTimeMS >= m_minLookTimeMS)
 			{
 				//HLook l(*m_pdirectionLookStarted, lookStartTimeMS, lastLookAwayStartTimeMS, cumulativeLookTimeMS);
@@ -820,8 +826,9 @@ void HLooker::stopLooker(int tMS)
 					l.setLookMS(cumulativeLookTimeMS);
 				}
 				m_looks.append(l);
-				//qDebug() << "emit look(3): " << l;
-				//qDebug() << "sublooks follow" << endl << sublooks;
+
+				qDebug() << "emit look(3): " << l;
+				qDebug() << "sublooks follow" << endl << sublooks;
 				emit look(l);
 				m_bLookStarted = false;
 				m_iLookStartedIndex = -1;
@@ -850,8 +857,8 @@ void HLooker::stopLooker(int tMS)
 					l.setLookMS(cumulativeLookTimeMS);
 				}
 				m_looks.append(l);
-				//qDebug() << "emit look(4): " << l;
-				//qDebug() << "sublooks follow" << endl << sublooks;
+				qDebug() << "emit look(4): " << l;
+				qDebug() << "sublooks follow" << endl << sublooks;
 				emit look(l);
 				m_bLookStarted = false;
 				m_iLookStartedIndex = -1;

--- a/libs/habutil/HLooker.h
+++ b/libs/habutil/HLooker.h
@@ -77,7 +77,7 @@ public slots:
 	void onLookingAwayStateEntered();
 	void onLookingAwayStateExited();
 	void onStarted();
-
+	void onRunningChanged(bool);
 
 	// slot called when state machine is stopped (i.e. when stop() is called).
 	// Should always call the overloaded stop(int tMS) so a proper stop time is

--- a/libs/habutil/HQEvents.h
+++ b/libs/habutil/HQEvents.h
@@ -16,6 +16,8 @@ class HEvent;
 class HLookTrans;
 
 
+
+
 struct HAllTrialsDoneEvent : public QEvent
 {
 	HAllTrialsDoneEvent() : QEvent(Type(AllTrialsDoneType)) {};
@@ -37,29 +39,40 @@ struct HAbortTrialQEvent : public QEvent
 	enum { AbortTrialType = QEvent::User + 3 };
 };
 
-class HReliabilityQEvent : public QEvent
-{
-public:
-	HReliabilityQEvent(HEvent* phevent) : QEvent(Type(ReliabilityType)), m_phevent(phevent) {};
-	~HReliabilityQEvent() {};
-	enum { ReliabilityType = QEvent::User + 4 };
-	HEvent* hevent() { return m_phevent; };
-private:
-	HEvent* m_phevent;
-};
-
-struct HReliabilityEndQEvent : public QEvent
-{
-	HReliabilityEndQEvent() : QEvent(Type(ReliabilityEndType)) {};
-	~HReliabilityEndQEvent() {};
-	enum { ReliabilityEndType = QEvent::User + 5 };
-};
 
 struct HNoLookQEvent : public QEvent
 {
 	HNoLookQEvent() : QEvent(Type(NoLookType)) {};
 	~HNoLookQEvent() {};
 	enum { NoLookType = QEvent::User + 6 };
+};
+
+struct HMaxLookAwayTimeQEvent : public QEvent
+{
+	HMaxLookAwayTimeQEvent() : QEvent(Type(MaxLookAwayTimeType)) {};
+	~HMaxLookAwayTimeQEvent() {};
+	enum { MaxLookAwayTimeType = QEvent::User + 4 };
+};
+
+struct HGotLookQEvent : public QEvent
+{
+	HGotLookQEvent() : QEvent(Type(GotLookType)) {};
+	~HGotLookQEvent() {};
+	enum { GotLookType = QEvent::User + 5 };
+};
+
+struct HMaxAccumulatedLookTimeQEvent : public QEvent
+{
+	HMaxAccumulatedLookTimeQEvent() : QEvent(Type(MaxAccumLookTimeType)) {};
+	~HMaxAccumulatedLookTimeQEvent() {};
+	enum { MaxAccumLookTimeType = QEvent::User + 7 };
+};
+
+struct HPhaseAccumulatedLookTimeQEvent : public QEvent
+{
+	HPhaseAccumulatedLookTimeQEvent() : QEvent(Type(PhaseAccumulatedLookTimeType)) {};
+	~HPhaseAccumulatedLookTimeQEvent() {};
+	enum { PhaseAccumulatedLookTimeType = QEvent::User + 8 };
 };
 
 

--- a/libs/habutil/HResults.cpp
+++ b/libs/habutil/HResults.cpp
@@ -58,22 +58,6 @@ HResults::HResults(const Habit::ExperimentSettings& es, const Habit::RunSettings
 {};
 
 
-// This constructor used for RELIABILTY RUN
-
-/*
- * 2-24-15 djs Remove reliability settings for now, clearing out unused code. Will probably need to add this back soon. Cleaner, I hope.
-HResults::HResults(const Habit::ExperimentSettings& es, const Habit::RunSettings& rs, const Habit::ReliabilitySettings& bs, const HEventLog& log, const QString origFilename, const QString filename, const QString version)
-: m_version(version)
-, m_originalFilename(origFilename)
-, m_filename(filename)
-, m_pResultsType(&HResultsType::HResultsTypeReliabilityRun)
-, m_experimentSettings(es)
-, m_runSettings(rs)
-, m_reliabilitySettings(bs)
-, m_log(log)
-{};
-*/
-
 HResults::~HResults() {};
 
 // Save
@@ -139,8 +123,6 @@ HResults* HResults::load(const QString& filename)
 		else if (itype == HResultsType::HResultsTypeReliabilityRun.number())
 		{
 			qCritical() << "Loading reliability results not implemented!";
-			//in >> originalFilename >> es >> rs >> bs >> log;
-			//results = new HResults(es, rs, bs, log, originalFilename, filename);
 		}
 		file.close();
 	}

--- a/libs/habutil/HResults.h
+++ b/libs/habutil/HResults.h
@@ -46,6 +46,9 @@ public:
 	// Load an HResults object from a file.
 	static HResults* load(const QString& filename);
 
+	// Analyze results file -- look for duplicate Look
+	static int checkHabFileForDups(const QString& sPath, QTextStream& output);
+
 	// save to file. File will be CLOBBERED!
 	bool save(const QString& filename) const;
 

--- a/libs/habutil/HTrial.cpp
+++ b/libs/habutil/HTrial.cpp
@@ -129,13 +129,19 @@ HTrial::HTrial(HPhase& phase, HEventLog& log, const Habit::HPhaseSettings& phase
 		if (m_phaseSettings.getIsSingleLook())
 		{
 			HGotLookState* sGotLook = new HGotLookState(*this, log);
-			sStimRunning->addTransition(&phase.experiment().getLookDetector(), SIGNAL(look(HLook)), sGotLook);
+			HGotLookTransition* pGotLookTrans = new HGotLookTransition();
+			pGotLookTrans->setTargetState(sGotLook);
+			sStimRunning->addTransition(pGotLookTrans);
+//			sStimRunning->addTransition(&phase.experiment().getLookDetector(), SIGNAL(look(HLook)), sGotLook);
 			sGotLook->addTransition(sFinal);
 		}
 		if (m_phaseSettings.getIsMaxAccumulatedLookTime())
 		{
 			HMaxAccumulatedLookTimeState* sMaxAccum = new HMaxAccumulatedLookTimeState(*this, log);
-			sStimRunning->addTransition(&phase.experiment().getLookDetector(), SIGNAL(maxAccumulatedLookTime()), sMaxAccum);
+			HMaxAccumulatedLookTimeTransition* pMaxTrans = new HMaxAccumulatedLookTimeTransition();
+			pMaxTrans->setTargetState(sMaxAccum);
+			sStimRunning->addTransition(pMaxTrans);
+//			sStimRunning->addTransition(&phase.experiment().getLookDetector(), SIGNAL(maxAccumulatedLookTime()), sMaxAccum);
 			sMaxAccum->addTransition(sFinal);
 		}
 	}
@@ -145,7 +151,10 @@ HTrial::HTrial(HPhase& phase, HEventLog& log, const Habit::HPhaseSettings& phase
 	if (m_phaseSettings.habituationSettings().getHabituationType() == HHabituationType::HHabituationTypeTotalLookingTime)
 	{
 		HPhaseAccumulatedLookTimeState *sPhaseAccum = new HPhaseAccumulatedLookTimeState(*this, log);
-		sStimRunning->addTransition(&phase.experiment().getLookDetector(), SIGNAL(phaseAccumulatedLookTime()), sPhaseAccum);
+		HPhaseAccumulatedLookTimeTransition *sPhaseTrans = new HPhaseAccumulatedLookTimeTransition();
+		sPhaseTrans->setTargetState(sPhaseAccum);
+		sStimRunning->addTransition(sPhaseTrans);
+//		sStimRunning->addTransition(&phase.experiment().getLookDetector(), SIGNAL(phaseAccumulatedLookTime()), sPhaseAccum);
 		sPhaseAccum->addTransition(sFinal);
 	}
 

--- a/libs/habutil/HTrialChildState.h
+++ b/libs/habutil/HTrialChildState.h
@@ -150,6 +150,77 @@ protected:
 	void onEntry(QEvent* e);
 };
 
+
+class HMaxLookAwayTimeTransition: public QAbstractTransition
+{
+
+public:
+	HMaxLookAwayTimeTransition() {};
+	~HMaxLookAwayTimeTransition() {};
+protected:
+	bool eventTest(QEvent* e)
+	{
+		return (e->type() == QEvent::Type(HMaxLookAwayTimeQEvent::MaxLookAwayTimeType));
+	};
+	virtual void onTransition(QEvent* event)
+	{
+		Q_UNUSED(event);
+	};
+};
+
+
+class HGotLookTransition: public QAbstractTransition
+{
+
+public:
+	HGotLookTransition() {};
+	~HGotLookTransition() {};
+protected:
+	bool eventTest(QEvent* e)
+	{
+		return (e->type() == QEvent::Type(HGotLookQEvent::GotLookType));
+	};
+	virtual void onTransition(QEvent* event)
+	{
+		Q_UNUSED(event);
+	};
+};
+
+class HMaxAccumulatedLookTimeTransition: public QAbstractTransition
+{
+
+public:
+	HMaxAccumulatedLookTimeTransition() {};
+	~HMaxAccumulatedLookTimeTransition() {};
+protected:
+	bool eventTest(QEvent* e)
+	{
+		return (e->type() == QEvent::Type(HMaxAccumulatedLookTimeQEvent::MaxAccumLookTimeType));
+	};
+	virtual void onTransition(QEvent* event)
+	{
+		Q_UNUSED(event);
+	};
+};
+
+class HPhaseAccumulatedLookTimeTransition: public QAbstractTransition
+{
+
+public:
+	HPhaseAccumulatedLookTimeTransition() {};
+	~HPhaseAccumulatedLookTimeTransition() {};
+protected:
+	bool eventTest(QEvent* e)
+	{
+		return (e->type() == QEvent::Type(HPhaseAccumulatedLookTimeQEvent::PhaseAccumulatedLookTimeType));
+	};
+	virtual void onTransition(QEvent* event)
+	{
+		Q_UNUSED(event);
+	};
+};
+
+
 class HMaxStimulusTimeState: public HTrialChildState
 {
 	

--- a/libs/habutil/HTrialResult.cpp
+++ b/libs/habutil/HTrialResult.cpp
@@ -265,6 +265,8 @@ void HTrialResult::setLooks(const QList<HLook>& looks)
 
 void HTrialResult::appendLook(const HLook& look)
 {
+	if (m_looks.contains(look))
+		qDebug() << "HTrialResult::appendLook: duplicated look: " << look;
 	m_looks.append(look);
 }
 

--- a/libs/habutil/HTrialScanner.cpp
+++ b/libs/habutil/HTrialScanner.cpp
@@ -8,7 +8,7 @@
 #include "HTrialScanner.h"
 #include "HLookerReprocessor.h"
 
-bool HTrialScanner::scan(const HResults& results, QStringList *pSErrorWarnings)
+bool HTrialScanner::scan(const HResults& results, QTextStream& output)
 {
 	bool b = true;
 	QString subjectId;
@@ -29,8 +29,7 @@ bool HTrialScanner::scan(const HResults& results, QStringList *pSErrorWarnings)
 	}
 	else
 	{
-		if (pSErrorWarnings)
-			pSErrorWarnings->append("Unknown results type. Cannot save HResults to CSV.");
+		output << "Unknown results type. Cannot save HResults to CSV." << Qt::endl;
 		return false;
 	}
 
@@ -80,8 +79,7 @@ bool HTrialScanner::scan(const HResults& results, QStringList *pSErrorWarnings)
 				if (bInsidePhase)
 				{
 					qCritical("Found phase start without preceding phase end event!");
-					if (pSErrorWarnings)
-						pSErrorWarnings->append("Found phase start without preceding phase end event!");
+					output << "Found phase start without preceding phase end event!";
 				}
 				bInsidePhase = true;
 			}
@@ -96,8 +94,7 @@ bool HTrialScanner::scan(const HResults& results, QStringList *pSErrorWarnings)
 				if (bInsideTrial)
 				{
 					qCritical("Found trial start without preceding trial end event!");
-					if (pSErrorWarnings)
-						pSErrorWarnings->append("Found trial start without preceding trial end event!");
+					output << "Found trial start without preceding trial end event!";
 				}
 
 				// initialize trialResult
@@ -156,8 +153,7 @@ bool HTrialScanner::scan(const HResults& results, QStringList *pSErrorWarnings)
 					else
 					{
 						qWarning() << "Warning: cannot match player id to monitor.";
-						if (pSErrorWarnings)
-							pSErrorWarnings->append("Warning: cannot match player id to monitor.");
+						output << "Warning: cannot match player id to monitor.";
 					}
 				}
 			}
@@ -166,14 +162,8 @@ bool HTrialScanner::scan(const HResults& results, QStringList *pSErrorWarnings)
 				HLookEvent* ple = static_cast<HLookEvent*>(e);
 				if (trialResult.looks().contains(ple->look()))
 				{
-					if (pSErrorWarnings)
-					{
-						QString s;
-						QTextStream tmpStream(&s);
-						tmpStream << "Phase: " << trialResult.getString(HTrialResult::indPhase) << " Trial: " << trialResult.getString(HTrialResult::indTrial) << endl;
-						tmpStream << "   Duplicate look: " << ple->look();
-						pSErrorWarnings->append(s);
-					}
+					output << "Phase: " << trialResult.getString(HTrialResult::indPhase) << " Trial: " << trialResult.getString(HTrialResult::indTrial) << Qt::endl;
+					output << "   Duplicate look: " << ple->look() << Qt::endl;
 					qWarning() << "Duplicate look: " << ple->look();
 				}
 				else
@@ -234,7 +224,7 @@ bool HTrialScanner::scan(const HResults& results, QStringList *pSErrorWarnings)
 bool CSV1ResultsScanner::init() const
 {
 	// put headers in output file
-	out() << HTrialResult::headers.join(",") << endl;
+	out() << HTrialResult::headers.join(",") << Qt::endl;
 	return true;
 }
 
@@ -268,7 +258,7 @@ bool CSV1ResultsScanner::trial(const HTrialResult& row) const
 		if (l.isComplete())
 			out() << "," << l.direction().name() << "," << l.startMS() << "," << l.endMS() << "," << l.lookMS();
 	}
-	out() << endl;
+	out() << Qt::endl;
 	return true;
 }
 
@@ -282,7 +272,7 @@ bool CSV2ResultsScanner::init() const
 	out() << HTrialResult::headers.at(HTrialResult::indPhase) << ","
 			<< HTrialResult::headers.at(HTrialResult::indTrial) << ","
 			<< HTrialResult::headers.at(HTrialResult::indRepeat) << ","
-			<< "Num,Complete,Direction,Start,End,Diff" << endl;
+			<< "Num,Complete,Direction,Start,End,Diff" << Qt::endl;
 	return true;
 }
 
@@ -300,7 +290,7 @@ bool CSV2ResultsScanner::trial(const HTrialResult& row) const
 			out() << row.getString(HTrialResult::indPhase) << ","
 					<< row.getString(HTrialResult::indTrial) << ","
 					<< row.getString(HTrialResult::indRepeat) << ","
-					<< num << ",FALSE," << l.direction().name() << "," << l.startMS() << "," << l.endMS() << "," << l.lookMS() << endl;
+					<< num << ",FALSE," << l.direction().name() << "," << l.startMS() << "," << l.endMS() << "," << l.lookMS() << Qt::endl;
 		}
 		else
 		{
@@ -311,7 +301,7 @@ bool CSV2ResultsScanner::trial(const HTrialResult& row) const
 					out() << row.getString(HTrialResult::indPhase) << ","
 							<< row.getString(HTrialResult::indTrial) << ","
 							<< row.getString(HTrialResult::indRepeat) << ","
-							<< num << ",TRUE," << sub.direction().name() << "," << sub.startMS() << "," << sub.endMS() << "," << sub.lookMS() << endl;
+							<< num << ",TRUE," << sub.direction().name() << "," << sub.startMS() << "," << sub.endMS() << "," << sub.lookMS() << Qt::endl;
 				}
 			}
 		}

--- a/libs/habutil/HTrialScanner.cpp
+++ b/libs/habutil/HTrialScanner.cpp
@@ -8,14 +8,217 @@
 #include "HTrialScanner.h"
 #include "HLookerReprocessor.h"
 
-bool CSV1ResultsDumper::init() const
+bool HTrialScanner::scan(const HResults& results)
+{
+	bool b = true;
+	QString subjectId;
+	QMap<int, QString> mapStimIdNames;
+
+	b = true;
+	if (results.type() == HResultsType::HResultsTypeOriginalRun)
+	{
+		subjectId = results.subjectSettings().getSubjectName();
+	}
+	else if (results.type() == HResultsType::HResultsTypeTestRun)
+	{
+		subjectId = QString("TESTING");
+	}
+	else if (results.type() == HResultsType::HResultsTypeReliabilityRun)
+	{
+		subjectId = QString("R-%1").arg(results.subjectSettings().getSubjectName());
+	}
+	else
+	{
+		qCritical() << "Unknown results type. Cannot save HResults to CSV.";
+		return false;
+	}
+
+	b = this->init();
+
+
+	if (b)
+	{
+		QString sPhase;
+		HTrialResult trialResult;
+		bool bInsidePhase = false;
+		bool bInsideTrial = false;
+		bool bHabituated = false;
+		bool bHaveStimRequest = false;
+		QString sPendingStimLabel;
+		QString sOrderName;
+		HEvent* e;
+
+		foreach(e, results.eventLog())
+		{
+
+			if (e->type() == HEventType::HEventPhaseStart)
+			{
+				HPhaseStartEvent* pse = static_cast<HPhaseStartEvent*>(e);
+				sPhase = pse->phase();
+				sOrderName = "";
+				if (results.runSettings().map().contains(pse->seqno()))
+				{
+					Habit::PhaseRunSettings prs = results.runSettings().map().value(pse->seqno());
+					sOrderName = prs.getOrderName();
+					if (sOrderName.isEmpty()) sOrderName = "default";
+
+					if (prs.isOrderRandomized())
+					{
+						sOrderName += " (" + getRandomizationType(prs.getRandomizeMethod()).name() + ")";
+					}
+					else
+					{
+						sOrderName += " (none)";
+					}
+
+				}
+				else
+				{
+					sOrderName = "unknown (unknown)";
+				}
+
+				if (bInsidePhase) qCritical("Found phase start without preceding phase end event!");
+				bInsidePhase = true;
+			}
+			else if (e->type() == HEventType::HEventPhaseEnd)
+			{
+				bInsidePhase = false;
+			}
+			else if (e->type() == HEventType::HEventTrialStart)
+			{
+				HTrialStartEvent* ptse = static_cast<HTrialStartEvent*>(e);
+				bHaveStimRequest = false;
+				if (bInsideTrial) qCritical("Found trial start without preceding trial end event!");
+
+				// initialize trialResult
+				trialResult = HTrialResult(HTrialKey(sPhase, ptse->trialnumber()+1, ptse->repeatnumber()));
+
+				// throw in
+				trialResult.setSubjectID(subjectId);
+				if (bHabituated)
+					trialResult.setHabituated(true);
+				else
+					trialResult.setHabituated(false);
+				trialResult.setTrialStartTime(ptse->timestamp());
+			}
+			else if (e->type() == HEventType::HEventStimRequest)
+			{
+				bHaveStimRequest = true;
+				sPendingStimLabel = "";
+			}
+			else if (e->type() == HEventType::HEventStimLabelRequest)
+			{
+				HStimLabelRequestEvent* pslre = static_cast<HStimLabelRequestEvent*>(e);
+				bHaveStimRequest = true;
+				sPendingStimLabel = pslre->label();
+			}
+			else if (e->type() == HEventType::HEventStimStart)
+			{
+				HStimStartEvent* psse = static_cast<HStimStartEvent*>(e);
+				trialResult.setStimId(psse->stimid());
+				trialResult.setStimName(mapStimIdNames.value(psse->stimid()));
+				trialResult.setStimLabel(sPendingStimLabel);
+			}
+			else if (e->type() == HEventType::HEventScreenStart)
+			{
+				HScreenStartEvent* psse = static_cast<HScreenStartEvent*>(e);
+				const HPlayerPositionType& ppt = getPlayerPositionType(psse->playerid());
+				// Do not keep filename unless stim request has been seen. Otherwise we will
+				// record attention getter file(s).
+				if (bHaveStimRequest)
+				{
+					if (ppt == HPlayerPositionType::Sound)
+					{
+						trialResult.setStimISS(psse->filename());
+					}
+					else if (ppt == HPlayerPositionType::Left)
+					{
+						trialResult.setStimLeft(psse->filename());
+					}
+					else if (ppt == HPlayerPositionType::Right)
+					{
+						trialResult.setStimRight(psse->filename());
+					}
+					else if (ppt == HPlayerPositionType::Center)
+					{
+						trialResult.setStimCenter(psse->filename());
+					}
+					else
+					{
+						qWarning() << "Warning: cannot match player id to monitor.";
+					}
+				}
+			}
+			else if (e->type() == HEventType::HEventLook)
+			{
+				HLookEvent* ple = static_cast<HLookEvent*>(e);
+				if (trialResult.looks().contains(ple->look()))
+				{
+					qWarning() << "Duplicate look: " << ple->look();
+				}
+				else
+				{
+					trialResult.appendLook(ple->look());
+				}
+			}
+			else if (e->type() == HEventType::HEventIncompleteLook)
+			{
+				HIncompleteLookEvent* ple = static_cast<HIncompleteLookEvent*>(e);
+				trialResult.appendLook(ple->look());
+			}
+			else if (e->type() == HEventType::HEventLookTrans)
+			{
+				trialResult.appendEvent(e);
+			}
+			else if (e->type() == HEventType::HEventLookEnabled)
+			{
+				HLookEnabledEvent* ple = static_cast<HLookEnabledEvent*>(e);
+				trialResult.setLookEnabledTime(ple->timestamp());
+				trialResult.appendEvent(e);
+			}
+			else if (e->type() == HEventType::HEventLookDisabled)
+			{
+				HLookDisabledEvent* pld = static_cast<HLookDisabledEvent*>(e);
+				trialResult.setLookDisabledTime(pld->timestamp());
+				trialResult.appendEvent(e);
+			}
+			else if (e->type() == HEventType::HEventTrialEnd)
+			{
+				// set trial end type and flush
+				HTrialEndEvent* pte = static_cast<HTrialEndEvent*>(e);
+				trialResult.setEndType(pte->endtype().name());
+				trialResult.setTrialEndTime(pte->timestamp());	// automatically sets total look(away) times
+				trialResult.setOrderName(sOrderName);
+
+				this->trial(trialResult);
+
+				// clear pending stim label
+				sPendingStimLabel = "";
+			}
+			else if (e->type() == HEventType::HEventStimulusSettings)
+			{
+				HStimulusSettingsEvent* pss = static_cast<HStimulusSettingsEvent*>(e);
+				mapStimIdNames.insert(pss->stimindex(), pss->settings().getName());
+			}
+			else if (e->type() == HEventType::HHabituationSuccess)
+			{
+				bHabituated = true;
+			}
+		}
+	}
+	if (b) b = this->done();
+	return b;
+}
+
+
+bool CSV1ResultsScanner::init() const
 {
 	// put headers in output file
 	out() << HTrialResult::headers.join(",") << endl;
 	return true;
 }
 
-bool CSV1ResultsDumper::trial(const HTrialResult& row) const
+bool CSV1ResultsScanner::trial(const HTrialResult& row) const
 {
 	HLook l;
 	out() << row.getString(HTrialResult::indSubjectId)
@@ -49,12 +252,12 @@ bool CSV1ResultsDumper::trial(const HTrialResult& row) const
 	return true;
 }
 
-bool CSV1ResultsDumper::done() const
+bool CSV1ResultsScanner::done() const
 {
 	return true;
 }
 
-bool CSV2ResultsDumper::init() const
+bool CSV2ResultsScanner::init() const
 {
 	out() << HTrialResult::headers.at(HTrialResult::indPhase) << ","
 			<< HTrialResult::headers.at(HTrialResult::indTrial) << ","
@@ -63,7 +266,7 @@ bool CSV2ResultsDumper::init() const
 	return true;
 }
 
-bool CSV2ResultsDumper::trial(const HTrialResult& row) const
+bool CSV2ResultsScanner::trial(const HTrialResult& row) const
 {
 	int num=0;
 	HLook l;
@@ -96,13 +299,13 @@ bool CSV2ResultsDumper::trial(const HTrialResult& row) const
 	return true;
 }
 
-bool CSV2ResultsDumper::done() const
+bool CSV2ResultsScanner::done() const
 {
 	return true;
 }
 
-ReplaceLooksResultsDumper::ReplaceLooksResultsDumper(const Habit::HLookSettings& settings, const HTextResultsDumper& dumper)
-: HTextResultsDumper(dumper.out())
+ReplaceLooksResultsDumper::ReplaceLooksResultsDumper(const Habit::HLookSettings& settings, const HTextResultsScanner& dumper)
+: HTextResultsScanner(dumper.out())
 , m_dumper(dumper)
 , m_lookSettings(settings)
 {

--- a/libs/habutil/HTrialScanner.h
+++ b/libs/habutil/HTrialScanner.h
@@ -21,7 +21,7 @@ public:
 	virtual bool init() const = 0;
 	virtual bool trial(const HTrialResult& t) const = 0;
 	virtual bool done() const = 0;
-	virtual bool scan(const HResults& results, QStringList *pSErrorWarnings = nullptr);
+	virtual bool scan(const HResults& results, QTextStream& output);
 };
 
 class NoopResultsScanner: public HTrialScanner

--- a/libs/habutil/HTrialScanner.h
+++ b/libs/habutil/HTrialScanner.h
@@ -10,6 +10,7 @@
 
 #include "HTrialResult.h"
 #include "HLookSettings.h"
+#include "HResults.h"
 
 class HTrialScanner
 {
@@ -20,47 +21,48 @@ public:
 	virtual bool init() const = 0;
 	virtual bool trial(const HTrialResult& t) const = 0;
 	virtual bool done() const = 0;
+	virtual bool scan(const HResults& results);
 };
 
-class HTextResultsDumper: public HTrialScanner
+class HTextResultsScanner: public HTrialScanner
 {
 	QTextStream& m_out;
 	public:
-	HTextResultsDumper(QTextStream& out) : HTrialScanner(), m_out(out) {};
-	HTextResultsDumper(const HTextResultsDumper& d) : HTrialScanner(), m_out(d.out()) {};
-	virtual ~HTextResultsDumper() {};
+	HTextResultsScanner(QTextStream& out) : HTrialScanner(), m_out(out) {};
+	HTextResultsScanner(const HTextResultsScanner& d) : HTrialScanner(), m_out(d.out()) {};
+	virtual ~HTextResultsScanner() {};
 	QTextStream& out() const { return m_out; };
 };
 
-class CSV1ResultsDumper: public HTextResultsDumper
+class CSV1ResultsScanner: public HTextResultsScanner
 {
 	public:
-	CSV1ResultsDumper(QTextStream& out) : HTextResultsDumper(out) {};
-	CSV1ResultsDumper(const CSV1ResultsDumper& d) : HTextResultsDumper(d.out()) {};
-	virtual ~CSV1ResultsDumper() {};
+	CSV1ResultsScanner(QTextStream& out) : HTextResultsScanner(out) {};
+	CSV1ResultsScanner(const CSV1ResultsScanner& d) : HTextResultsScanner(d.out()) {};
+	virtual ~CSV1ResultsScanner() {};
 	virtual bool init() const;
 	virtual bool trial(const HTrialResult& t) const;
 	virtual bool done() const;
 };
 
-class CSV2ResultsDumper: public HTextResultsDumper
+class CSV2ResultsScanner: public HTextResultsScanner
 {
 	public:
-	CSV2ResultsDumper(QTextStream& out) : HTextResultsDumper(out) {};
-	CSV2ResultsDumper(const CSV2ResultsDumper& d) : HTextResultsDumper(d.out()) {};
-	virtual ~CSV2ResultsDumper() {};
+	CSV2ResultsScanner(QTextStream& out) : HTextResultsScanner(out) {};
+	CSV2ResultsScanner(const CSV2ResultsScanner& d) : HTextResultsScanner(d.out()) {};
+	virtual ~CSV2ResultsScanner() {};
 	virtual bool init() const;
 	virtual bool trial(const HTrialResult& t) const;
 	virtual bool done() const;
 };
 
-class ReplaceLooksResultsDumper: public HTextResultsDumper
+class ReplaceLooksResultsDumper: public HTextResultsScanner
 {
 private:
-	const HTextResultsDumper& m_dumper;
+	const HTextResultsScanner& m_dumper;
 	Habit::HLookSettings m_lookSettings;
 public:
-	ReplaceLooksResultsDumper(const Habit::HLookSettings& settings, const HTextResultsDumper& dumper);
+	ReplaceLooksResultsDumper(const Habit::HLookSettings& settings, const HTextResultsScanner& dumper);
 	virtual ~ReplaceLooksResultsDumper() {};
 	virtual bool init() const;
 	virtual bool trial(const HTrialResult& t) const;

--- a/libs/habutil/HTrialScanner.h
+++ b/libs/habutil/HTrialScanner.h
@@ -21,7 +21,17 @@ public:
 	virtual bool init() const = 0;
 	virtual bool trial(const HTrialResult& t) const = 0;
 	virtual bool done() const = 0;
-	virtual bool scan(const HResults& results);
+	virtual bool scan(const HResults& results, QStringList *pSErrorWarnings = nullptr);
+};
+
+class NoopResultsScanner: public HTrialScanner
+{
+public:
+	NoopResultsScanner(): HTrialScanner() {};
+	virtual ~NoopResultsScanner() {};
+	virtual bool init() const { return true; };
+	virtual bool trial(const HTrialResult& t) const { return true; };
+	virtual bool done() const { return true; };
 };
 
 class HTextResultsScanner: public HTrialScanner

--- a/libs/habutil/habit-files.pri
+++ b/libs/habutil/habit-files.pri
@@ -70,7 +70,8 @@
 	habit/HIntertrialIntervalSettingsWidget.h \
 	habit/HAboutHabitDialog.h \
 	habit/HLoggerObject.h  \
-	habit/HLoggerWidget.h
+	habit/HLoggerWidget.h \
+	habit/ResultsScannerDialog.h
 	
 	
 
@@ -141,7 +142,8 @@ SOURCES += \
 	habit/HIntertrialIntervalSettingsWidget.cpp \
 	habit/HAboutHabitDialog.cpp \
 	habit/HLoggerObject.cpp \
-	habit/HLoggerWidget.cpp
+	habit/HLoggerWidget.cpp \
+	habit/ResultsScannerDialog.cpp
 	
 
  FORMS =		\
@@ -170,5 +172,6 @@ SOURCES += \
  	habit/GlobalPreferencesDialog.ui \
  	habit/HRunSettingsTestingForm.ui \
  	habit/HIntertrialIntervalSettingsForm.ui \
- 	habit/AboutHabitDialog.ui
+ 	habit/AboutHabitDialog.ui \
+ 	habit/ResultsScannerForm.ui
  

--- a/libs/habutil/habit/HPhaseSettingsTabWidget.cpp
+++ b/libs/habutil/habit/HPhaseSettingsTabWidget.cpp
@@ -83,8 +83,8 @@ Habit::HPhaseSettings HPhaseSettingsTabWidget::getPhaseSettings()
 void HPhaseSettingsTabWidget::phaseNameTextChanged(const QString& text)
 {
     QFontMetrics fm(font());
-    int mWidth = fm.width("m");
-    int pixelsWide = mWidth * (text.size() + 2);
+    //int mWidth = fm.width("m");
+    int pixelsWide = fm.horizontalAdvance(text);
     int pixelsHigh = fm.height();
 
     m_plineeditPhaseName->setFixedSize(pixelsWide, pixelsHigh);

--- a/libs/habutil/habit/HResultsExplorerDialog.cpp
+++ b/libs/habutil/habit/HResultsExplorerDialog.cpp
@@ -9,6 +9,7 @@
 #include "HResultsDialog.h"
 #include "ui_HResultsExplorerForm.h"
 #include "HResults.h"
+#include "ResultsScannerDialog.h"
 #include <QtDebug>
 #include <QMessageBox>
 #include <QFileInfo>
@@ -186,9 +187,28 @@ void HResultsExplorerDialog::openClicked()
 
 void HResultsExplorerDialog::checkResultsClicked()
 {
-	qDebug() << "check results " << getSelectedFile();
+	QString s;
+	QTextStream output(&s);
+	QFileInfo selectedFile(getSelectedFile());
+	if (selectedFile.isDir())
+	{
+		output << "Checking dir: " << getSelectedFile();
+		// Scan folder for individual files
+	}
+	else
+	{
+		output << "Checking file: " << getSelectedFile() << Qt::endl;
+		int i = HResults::checkHabFileForDups(getSelectedFile(), output);
+		if (i > -1)
+			output << QString("Found %1 duplicate looks.").arg(i) << Qt::endl;
+		else
+			output << "Cannot open file." << Qt::endl;
+		qDebug().noquote() << s;
+	}
 
-	accept();
+	ResultsScannerDialog rsd(this, s);
+	rsd.show();
+	rsd.exec();
 }
 
 

--- a/libs/habutil/habit/HResultsExplorerDialog.cpp
+++ b/libs/habutil/habit/HResultsExplorerDialog.cpp
@@ -53,36 +53,21 @@ void HResultsExplorerDialog::initialize()
 	m_pFolderModel->setNameFilters(nameFilter);
 	m_pFolderModel->setNameFilterDisables(false);
 
-
-//	m_pFilesModel = new QFileSystemModel(this);
-//	m_pFilesModel->setRootPath(m_rootDir.absolutePath());
-//	m_pFilesModel->setFilter(QDir::NoDotAndDotDot | QDir::Files);
-//	m_pFilesModel->setNameFilters(nameFilter);
-//	m_pFilesModel->setNameFilterDisables(false);
-//
-//	m_pFilesProxyModel = new HResultsExplorerFilesProxyModel(m_pFilesModel, this);
-//	// done in constructor m_pFilesProxyModel->setSourceModel(m_pFilesModel);
-//
-//	ui->tableViewFiles->setModel(m_pFilesProxyModel);
-//	ui->tableViewFiles->setRootIndex(m_pFilesProxyModel->mapFromSource(m_pFilesModel->setRootPath(m_rootDir.absolutePath())));
-//	ui->tableViewFiles->setShowGrid(false);
-//	ui->tableViewFiles->verticalHeader()->hide();
-//	ui->tableViewFiles->horizontalHeader()->setStretchLastSection(true);
-//	ui->tableViewFiles->setSelectionBehavior(QAbstractItemView::SelectRows);
-
 	// Open pushbutton initially disabled - it is enabled when something is clicked.
 	ui->pbOpen->setEnabled(false);
+
+	// Check pushbutton initially disabled
+	ui->pbCheckResults->setEnabled(false);
 }
 
 void HResultsExplorerDialog::connections()
 {
 	connect(ui->pbCancel, SIGNAL(clicked()), this, SLOT(reject()));
 	connect(ui->pbOpen, SIGNAL(clicked()), this, SLOT(openClicked()));
+	connect(ui->pbCheckResults, SIGNAL(clicked()), this, SLOT(checkResultsClicked()));
 	connect(ui->treeViewFolders, SIGNAL(clicked(QModelIndex)), this, SLOT(itemClicked(QModelIndex)));
 	connect(ui->treeViewFolders, SIGNAL(activated(QModelIndex)), this, SLOT(itemActivated(QModelIndex)));
 	connect(ui->treeViewFolders->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&,const QItemSelection&)), this, SLOT(selectionChanged(const QItemSelection&,const QItemSelection&)));
-//	connect(ui->tableViewFiles, SIGNAL(clicked(QModelIndex)), this, SLOT(resultsFileClicked(QModelIndex)));
-//	connect(ui->tableViewFiles, SIGNAL(activated(QModelIndex)), this, SLOT(resultsFileActivated(QModelIndex)));
 }
 
 void HResultsExplorerDialog::itemClicked(QModelIndex index)
@@ -96,14 +81,33 @@ void HResultsExplorerDialog::itemClicked(QModelIndex index)
 void HResultsExplorerDialog::selectionChanged(const QItemSelection& selected,const QItemSelection&)
 {
 	QModelIndexList indexes = selected.indexes();
-	if (indexes.size() > 0 && m_pFolderModel->fileInfo(indexes.first()).isFile())
+	if (indexes.size() > 0)
 	{
-		ui->pbOpen->setEnabled(true);
+		if (m_pFolderModel->fileInfo(indexes.first()).isFile())
+		{
+			ui->pbOpen->setEnabled(true);
+			// only enable check button if its a results file
+			if (m_pFolderModel->fileInfo(indexes.first()).suffix().contains("hab", Qt::CaseInsensitive))
+			{
+				ui->pbCheckResults->setEnabled(true);
+			}
+			else
+			{
+				ui->pbCheckResults->setEnabled(false);
+			}
+		}
+		else
+		{
+			ui->pbOpen->setEnabled(false);
+			ui->pbCheckResults->setEnabled(true);
+		}
 	}
 	else
 	{
 		ui->pbOpen->setEnabled(false);
+		ui->pbCheckResults->setEnabled(false);
 	}
+
 }
 
 //void HResultsExplorerDialog::resultsFileClicked(QModelIndex index)
@@ -179,6 +183,14 @@ void HResultsExplorerDialog::openClicked()
 		showResultsFile(getSelectedFile());
 	accept();
 }
+
+void HResultsExplorerDialog::checkResultsClicked()
+{
+	qDebug() << "check results " << getSelectedFile();
+
+	accept();
+}
+
 
 QString HResultsExplorerDialog::getSelectedFile()
 {

--- a/libs/habutil/habit/HResultsExplorerDialog.h
+++ b/libs/habutil/habit/HResultsExplorerDialog.h
@@ -54,6 +54,7 @@ namespace GUILib
 //		void resultsFileActivated(QModelIndex index);
 		void itemActivated(QModelIndex index);
 		void openClicked();
+		void checkResultsClicked();
 		void selectionChanged(const QItemSelection&,const QItemSelection&);
 
 	public:

--- a/libs/habutil/habit/HResultsExplorerForm.ui
+++ b/libs/habutil/habit/HResultsExplorerForm.ui
@@ -13,52 +13,49 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <widget class="QWidget" name="layoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>12</x>
-     <y>20</y>
-     <width>531</width>
-     <height>301</height>
-    </rect>
-   </property>
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QTreeView" name="treeViewFolders"/>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbCancel">
-        <property name="text">
-         <string>Cancel</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbOpen">
-        <property name="text">
-         <string>Open</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-   </layout>
-  </widget>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTreeView" name="treeViewFolders"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pbCancel">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pbCheckResults">
+       <property name="text">
+        <string>Check Results</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pbOpen">
+       <property name="text">
+        <string>Open</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/libs/habutil/habit/ResultsScannerDialog.cpp
+++ b/libs/habutil/habit/ResultsScannerDialog.cpp
@@ -1,0 +1,25 @@
+/*
+ * ResultsExplorerDialog.cpp
+ *
+ *  Created on: Jul 30, 2021
+ *      Author: dan
+ */
+
+#include <ResultsScannerDialog.h>
+#include "ui_ResultsScannerForm.h"
+
+namespace GUILib {
+
+ResultsScannerDialog::ResultsScannerDialog(QWidget *parent, const QString& text)
+: QDialog(parent)
+, ui(new Ui::ResultsScannerForm())
+{
+	ui->setupUi(this);
+	ui->textEditScannerOutput->setText(text);
+}
+
+ResultsScannerDialog::~ResultsScannerDialog() {
+	delete ui;
+}
+
+} /* namespace GUILib */

--- a/libs/habutil/habit/ResultsScannerDialog.h
+++ b/libs/habutil/habit/ResultsScannerDialog.h
@@ -1,0 +1,32 @@
+/*
+ * ResultsExplorerDialog.h
+ *
+ *  Created on: Jul 30, 2021
+ *      Author: dan
+ */
+
+#ifndef HABIT_RESULTSSCANNERDIALOG_H_
+#define HABIT_RESULTSSCANNERDIALOG_H_
+
+#include <QDialog>
+
+namespace Ui
+{
+	class ResultsScannerForm;
+};
+
+namespace GUILib {
+
+class ResultsScannerDialog: public QDialog {
+	Ui::ResultsScannerForm *ui;
+
+public:
+	ResultsScannerDialog(QWidget *parent, const QString& text);
+	virtual ~ResultsScannerDialog();
+};
+
+} /* namespace GUILib */
+
+#endif /* HABIT_RESULTSSCANNERDIALOG_H_ */
+
+

--- a/libs/habutil/habit/ResultsScannerForm.ui
+++ b/libs/habutil/habit/ResultsScannerForm.ui
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ResultsScannerForm</class>
+ <widget class="QDialog" name="ResultsScannerForm">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>391</width>
+    <height>284</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Results Scanner</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTextEdit" name="textEditScannerOutput">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ResultsScannerForm</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ResultsScannerForm</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/libs/habutil/habit/resources/doc/about.html
+++ b/libs/habutil/habit/resources/doc/about.html
@@ -6,15 +6,14 @@
   </head>
   <body>
     <h1 align="center">Habit2</h1>
-    <div align="center">Version 2.2.1<br>
-      Build ID 2657<br>
+    <div align="center">Version 2.2.9<br>
     </div>
     <br>
     <br>
     <div align="left"> Habit is the proprietary property of The Regents
       of the University of California (“The Regents.”)<br>
       <br>
-      Copyright © 2018 The Regents of the University of California,
+      Copyright © 2022 The Regents of the University of California,
       Davis campus. All Rights Reserved. &nbsp;<br>
       <br>
       Redistribution and use in source and binary forms, with or without
@@ -76,7 +75,7 @@
       License, version 3. In Habit2, click "habit2 &gt; About Qt for
       details about the version used in habit2.<br>
       <br>
-      Gstreamer 1.12.4 (https://gstreamer.freedesktop.org) is released
+      Gstreamer 1.18.4 (https://gstreamer.freedesktop.org) is released
       under the Lesser Gnu Public License. <br>
       <br>
     </div>

--- a/testing/double-look-phase-accum.txt
+++ b/testing/double-look-phase-accum.txt
@@ -1,0 +1,53 @@
+# Look Settings 1000/1000 not inclusive
+# Trial: max stim = 10s
+#        max inattentive 1000ms
+# Phase: fixed 3 trials
+#
+#  Looking here is plenty, and 
+#  look-away time is exactly the min look-away in LookSettings. 
+#  SHOULD have a single look which ends trial. 
+First, 0, 0, NoneCenter, 1000
+First, 0, 0, CenterNone, 2100
+First, 0, 0, NoneCenter, 3100
+First, 0, 0, CenterNone, 3500
+#
+#
+First, 1, 0, NoneCenter, 1000
+First, 1, 0, CenterNone, 2100
+First, 1, 0, NoneCenter, 3100
+First, 1, 0, CenterNone, 3500
+#
+#
+First, 2, 0, NoneCenter, 1000
+First, 2, 0, CenterNone, 2100
+First, 2, 0, NoneCenter, 3100
+First, 2, 0, CenterNone, 3500
+#
+#
+First, 3, 0, NoneCenter, 1000
+First, 3, 0, CenterNone, 2100
+First, 3, 0, NoneCenter, 3100
+First, 3, 0, CenterNone, 3500
+#
+#
+First, 4, 0, NoneCenter, 1000
+First, 4, 0, CenterNone, 2100
+First, 4, 0, NoneCenter, 3100
+First, 4, 0, CenterNone, 3500
+#
+Second, 0, 0, NoneCenter, 1000
+Second, 0, 0, CenterNone, 2100
+Second, 0, 0, NoneCenter, 3100
+Second, 0, 0, CenterNone, 3500
+#
+#
+Second, 1, 0, NoneCenter, 1000
+Second, 1, 0, CenterNone, 2100
+Second, 1, 0, NoneCenter, 3100
+Second, 1, 0, CenterNone, 3500
+#
+#
+Second, 2, 0, NoneCenter, 1000
+Second, 2, 0, CenterNone, 2100
+Second, 2, 0, NoneCenter, 3100
+Second, 2, 0, CenterNone, 3500

--- a/testing/double-look-plus-1.txt
+++ b/testing/double-look-plus-1.txt
@@ -1,0 +1,25 @@
+# Look Settings 1000/1000 not inclusive
+# Trial: max stim = 10s
+#        max inattentive 1000ms
+# Phase: fixed 3 trials
+#
+#  Looking here is plenty, and 
+#  look-away time is 1ms more than the min look-away in LookSettings. 
+#  SHOULD have a single look which ends trial. 
+First, 0, 0, NoneCenter, 1000
+First, 0, 0, CenterNone, 2100
+First, 0, 0, NoneCenter, 3101
+First, 0, 0, CenterNone, 3500
+#
+#
+First, 1, 0, NoneCenter, 1000
+First, 1, 0, CenterNone, 2100
+First, 1, 0, NoneCenter, 3101
+First, 1, 0, CenterNone, 3500
+#
+#
+First, 2, 0, NoneCenter, 1000
+First, 2, 0, CenterNone, 2100
+First, 2, 0, NoneCenter, 3101
+First, 2, 0, CenterNone, 3500
+#

--- a/testing/double-look.txt
+++ b/testing/double-look.txt
@@ -1,0 +1,37 @@
+# Look Settings 1000/1000 not inclusive
+# Trial: max stim = 10s
+#        max inattentive 1000ms
+# Phase: fixed 3 trials
+#
+#  Looking here is plenty, and 
+#  look-away time is exactly the min look-away in LookSettings. 
+#  SHOULD have a single look which ends trial. 
+First, 0, 0, NoneCenter, 1000
+First, 0, 0, CenterNone, 2100
+First, 0, 0, NoneCenter, 3100
+First, 0, 0, CenterNone, 3500
+#
+#
+First, 1, 0, NoneCenter, 1000
+First, 1, 0, CenterNone, 2100
+First, 1, 0, NoneCenter, 3100
+First, 1, 0, CenterNone, 3500
+#
+#
+First, 2, 0, NoneCenter, 1000
+First, 2, 0, CenterNone, 2100
+First, 2, 0, NoneCenter, 3100
+First, 2, 0, CenterNone, 3500
+#
+#
+First, 3, 0, NoneCenter, 1000
+First, 3, 0, CenterNone, 2100
+First, 3, 0, NoneCenter, 3100
+First, 3, 0, CenterNone, 3500
+#
+#
+First, 4, 0, NoneCenter, 1000
+First, 4, 0, CenterNone, 2100
+First, 4, 0, NoneCenter, 3100
+First, 4, 0, CenterNone, 3500
+#

--- a/windows-setup/Habit2.wxs
+++ b/windows-setup/Habit2.wxs
@@ -38,7 +38,6 @@
 			<MergeRef Id="gstreamer_codecs"/>
 			<MergeRef Id="gstreamer_codecs_gpl"/>
 			<MergeRef Id="gstreamer_codecs_restricted"/>
-			<MergeRef Id="gstreamer_dvd"/>
 			<MergeRef Id="gstreamer_core"/>
 			<MergeRef Id="gstreamer_playback"/>
 			<MergeRef Id="gstreamer_effects"/>
@@ -72,18 +71,17 @@
 			<Directory Id="ProgramFiles64Folder" Name="PFiles">
 				<Directory Id="INSTALLDIR" Name="habit2">
 				    <Directory Id="GSTDIR" Name="gstreamer-1.0">
-					    <Merge Id="base_system" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\base-system-1.0-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
-					    <Merge Id="base_crypto" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\base-crypto-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
-					    <Merge Id="gstreamer_net" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\gstreamer-1.0-net-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
-					    <Merge Id="gstreamer_system" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\gstreamer-1.0-system-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
-					    <Merge Id="gstreamer_codecs" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\gstreamer-1.0-codecs-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
-					    <Merge Id="gstreamer_codecs_gpl" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\gstreamer-1.0-codecs-gpl-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
-					    <Merge Id="gstreamer_codecs_restricted" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\gstreamer-1.0-codecs-restricted-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
-					    <Merge Id="gstreamer_dvd" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\gstreamer-1.0-dvd-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
-					    <Merge Id="gstreamer_core" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\gstreamer-1.0-core-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
-					    <Merge Id="gstreamer_playback" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\gstreamer-1.0-playback-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
-					    <Merge Id="gstreamer_effects" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\gstreamer-1.0-effects-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
-					    <Merge Id="gstreamer_libav" SourceFile="C:\gstreamer-msm\MinGW\msys\1.0\home\Jan\cerbero\gstreamer-1.0-libav-1.12.4-x86_64.msm" DiskId="1" Language="1033"/>
+					    <Merge Id="base_system" SourceFile="C:\gstreamer-msm\1.18.4\base-system-1.0-msvc-x86_64-1.18.4.msm" DiskId="1" Language="1033"/>
+					    <Merge Id="base_crypto" SourceFile="C:\gstreamer-msm\1.18.4\base-crypto-msvc-x86_64-1.18.4.msm" DiskId="1" Language="1033"/>
+					    <Merge Id="gstreamer_net" SourceFile="C:\gstreamer-msm\1.18.4\gstreamer-1.0-net-msvc-x86_64-1.18.4.msm" DiskId="1" Language="1033"/>
+					    <Merge Id="gstreamer_system" SourceFile="C:\gstreamer-msm\1.18.4\gstreamer-1.0-system-msvc-x86_64-1.18.4.msm" DiskId="1" Language="1033"/>
+					    <Merge Id="gstreamer_codecs" SourceFile="C:\gstreamer-msm\1.18.4\gstreamer-1.0-codecs-msvc-x86_64-1.18.4.msm" DiskId="1" Language="1033"/>
+					    <Merge Id="gstreamer_codecs_gpl" SourceFile="C:\gstreamer-msm\1.18.4\gstreamer-1.0-codecs-gpl-msvc-x86_64-1.18.4.msm" DiskId="1" Language="1033"/>
+					    <Merge Id="gstreamer_codecs_restricted" SourceFile="C:\gstreamer-msm\1.18.4\gstreamer-1.0-codecs-restricted-msvc-x86_64-1.18.4.msm" DiskId="1" Language="1033"/>
+					    <Merge Id="gstreamer_core" SourceFile="C:\gstreamer-msm\1.18.4\gstreamer-1.0-core-msvc-x86_64-1.18.4.msm" DiskId="1" Language="1033"/>
+					    <Merge Id="gstreamer_playback" SourceFile="C:\gstreamer-msm\1.18.4\gstreamer-1.0-playback-msvc-x86_64-1.18.4.msm" DiskId="1" Language="1033"/>
+					    <Merge Id="gstreamer_effects" SourceFile="C:\gstreamer-msm\1.18.4\gstreamer-1.0-effects-msvc-x86_64-1.18.4.msm" DiskId="1" Language="1033"/>
+					    <Merge Id="gstreamer_libav" SourceFile="C:\gstreamer-msm\1.18.4\gstreamer-1.0-libav-msvc-x86_64-1.18.4.msm" DiskId="1" Language="1033"/>
 				    </Directory>
 				</Directory>
 			</Directory>
@@ -125,7 +123,7 @@
 	</Fragment>
 	<Fragment>
 		<DirectoryRef Id="TARGETDIR">
-			<Merge Id="VCRedist" SourceFile="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.13.26020\MergeModules\Microsoft_VC141_CRT_x64.msm" DiskId="1" Language="0"/>
+			<Merge Id="VCRedist" SourceFile="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\v142\MergeModules\Microsoft_VC142_CRT_x64.msm" DiskId="1" Language="0"/>
 		</DirectoryRef>
 	</Fragment>
 </Wix>

--- a/windows-setup/windist.mak
+++ b/windows-setup/windist.mak
@@ -1,16 +1,24 @@
 # env can contain these, else set them here
-GIT_TAG=v2.2.5-rc4
-DIST_VERSION=2.2.5
+GIT_TAG=v2.2.9-win2
+DIST_VERSION=2.2.9
 EXTRA_LABEL=_win_x64
-QT_BIN=C:\Qt\5.10.1\msvc2017_64\bin
+QT_BIN=C:\Qt\5.15.2\msvc2019_64\bin
 
 # qmake exe based on QT_BIN - this sets the qt version to use in the dist
 QMAKE=$(QT_BIN)\qmake.exe
 
+# path to sed exe
+SED="C:\Program Files\Git\usr\bin\sed.exe"
+
+# path to WIX tools
+HEAT="C:\Program Files (x86)\WiX Toolset v3.11\bin\heat.exe"
+LIGHT="C:\Program Files (x86)\WiX Toolset v3.11\bin\light.exe"
+CANDLE="C:\Program Files (x86)\WiX Toolset v3.11\bin\candle.exe"
+
 # export key from certmgr, set filename and password here
 # delete file when build is done!
-PFXFILE=ucd.pfx
-PFXKEY=horseyface
+PFXFILE=djsperka-win-2022.p12
+PFXKEY=horsCPh8s
 
 # Note: $(MAKEDIR) is the location of this makefile. 
 BUILDDIR=$(MAKEDIR)\build
@@ -57,7 +65,7 @@ clean:
 
 $(PACKAGE): $(BUILDDIR)\stamp-Directories $(BUILDDIR)\stamp-SignExe $(OBJS) 
 	echo "Building $(PACKAGE)"
-	-light -out $(PACKAGE) -ext $(WIXUIEXTENSION) -nologo $(OBJS)
+	-$(LIGHT) -out $(PACKAGE) -ext $(WIXUIEXTENSION) -nologo $(OBJS)
 	signtool sign /a /t http://timestamp.comodoca.com /f $(PFXFILE) /p "$(PFXKEY)" $(PACKAGE)
 
 Package: Directories $(PACKAGE)
@@ -89,8 +97,8 @@ $(BUILDDIR)\stamp-BuildSrc: $(BUILDDIR)\stamp-PatchSrc
 PatchSrc: $(BUILDDIR)\stamp-PatchSrc
 
 $(BUILDDIR)\stamp-PatchSrc: $(BUILDDIR)\stamp-QMakeSrc
-	sed -i '/ProductVersion/s/\".*\"/\"$(DIST_VERSION)\"/' HabitConfiguration.wxi
-	sed -i '/HABIT_VERSION/s/\".*\"/\"$(DIST_VERSION)\"/' $(SRCDIR)\apps\habit\version.h
+	$(SED) -i '/ProductVersion/s/\".*\"/\"$(DIST_VERSION)\"/' HabitConfiguration.wxi
+	$(SED) -i '/HABIT_VERSION/s/\".*\"/\"$(DIST_VERSION)\"/' $(SRCDIR)\apps\habit\version.h
 	copy /y /b NUL $@
 
 QMakeSrc: $(BUILDDIR)\stamp-QMakeSrc
@@ -107,16 +115,16 @@ $(BUILDDIR)\stamp-DownloadSrc: DIRECTORIES
 	copy /y /b NUL $@	
 	
 $(OBJDIR)\Habit2.wixobj: Habit2.wxs
-	candle -dStimFolder=$(DISTSTIMDIR) -dStagingFolder=$(STAGINGDIR) -nologo -out $@ -arch x86 -ext "C:\Program Files (x86)\WiX Toolset v3.11\bin\\WixUIExtension.dll" $? 
+	$(CANDLE) -dStimFolder=$(DISTSTIMDIR) -dStagingFolder=$(STAGINGDIR) -nologo -out $@ -arch x86 -ext "C:\Program Files (x86)\WiX Toolset v3.11\bin\\WixUIExtension.dll" $? 
 
 $(OBJDIR)\StimComponents.wixobj: $(GENDIR)\StimComponents.wxs
-	candle -dStimFolder=$(DISTSTIMDIR) -dStagingFolder=$(STAGINGDIR) -nologo -out $@ -arch x86 -ext "C:\Program Files (x86)\WiX Toolset v3.11\bin\\WixUIExtension.dll" $? 
+	$(CANDLE) -dStimFolder=$(DISTSTIMDIR) -dStagingFolder=$(STAGINGDIR) -nologo -out $@ -arch x86 -ext "C:\Program Files (x86)\WiX Toolset v3.11\bin\\WixUIExtension.dll" $? 
 
 $(OBJDIR)\HabitComponents.wixobj: $(GENDIR)\HabitComponents.wxs
-	candle -dStimFolder=$(DISTSTIMDIR) -dStagingFolder=$(STAGINGDIR) -nologo -out $@ -arch x86 -ext "C:\Program Files (x86)\WiX Toolset v3.11\bin\\WixUIExtension.dll" $? 
+	$(CANDLE) -dStimFolder=$(DISTSTIMDIR) -dStagingFolder=$(STAGINGDIR) -nologo -out $@ -arch x86 -ext "C:\Program Files (x86)\WiX Toolset v3.11\bin\\WixUIExtension.dll" $? 
 
 $(GENDIR)\StimComponents.wxs:
-	heat dir $(DISTSTIMDIR) -cg StimComponents -dr STIMDIR -sreg -srd -var var.StimFolder -nologo -ag -out $@
+	$(HEAT) dir $(DISTSTIMDIR) -cg StimComponents -dr STIMDIR -sreg -srd -var var.StimFolder -nologo -ag -out $@
 	
 $(GENDIR)\HabitComponents.wxs:
-	heat dir $(STAGINGDIR) -cg HabitComponents -dr INSTALLDIR -sreg -srd -var var.StagingFolder -nologo -ag -out $@
+	$(HEAT) dir $(STAGINGDIR) -cg HabitComponents -dr INSTALLDIR -sreg -srd -var var.StagingFolder -nologo -ag -out $@


### PR DESCRIPTION

Trials with these settings:

Single complete look to end

AND 

keystroke moving from look away to look coming when look is complete (before the min look away timer fires, but after its time has expired, so the looking satisfies min look requirement). 

Trial state transition from StimRunning -> GotLook due to SIGNAL(look())
This causes SIGNAL(exited()) from StimRunning, and onStimRunningExited() then calls lookDetector.disable(). 
lookDetector.disable() calls stopLooker()
stopLooker() then re-analyzes looking, which had not been updated to reflect that a look() was emitted. That analysis then finds the SAME LOOK AGAIN, and re-emits it. 

